### PR TITLE
km-11-display-customer

### DIFF
--- a/Controllers/CustomerController.cs
+++ b/Controllers/CustomerController.cs
@@ -35,8 +35,9 @@ namespace BangazonAPI.Controllers
 
         }
 
+
         // GET api/values/5
-        [HttpGet("{id}", Name="GetSingleCustomer")]
+        [HttpGet("{id:int}", Name="GetSingleCustomer")]
         public IActionResult Get(int id)
         {
             if (!ModelState.IsValid)
@@ -61,6 +62,30 @@ namespace BangazonAPI.Controllers
             }
         }
 
+        [HttpGet("{active:bool}",Name="GetActiveCustomers")]
+        public IActionResult GetActive(bool active=true)
+        {
+            
+            // // var customer = _context.Customer.ToList();
+            // var customer = from c in _context.Customer
+            //     join o in _context.Order on c.CustomerId equals o.CustomerId into gj
+            //     from subOrder in gj.DefaultIfEmpty()
+            //     select new { c.FirstName, c.LastName };
+
+            // if (customer == null)
+            // {
+            //     return NotFound();
+            // }
+
+            string color = "Yellow";
+            if (active) {
+               color = "Blue";
+            } 
+
+            var obj = new {name = color, active = active};
+            return Ok(obj);
+
+        }
         // POST api/values
         [HttpPost]
         public IActionResult Post([FromBody]Customer customer)

--- a/Controllers/CustomerController.cs
+++ b/Controllers/CustomerController.cs
@@ -22,21 +22,49 @@ namespace BangazonAPI.Controllers
 
         // GET api/values
         [HttpGet]
-        public IActionResult Get()
+        public IActionResult Get(string active)
         {
-            
-            var customer = _context.Customer.ToList();
+            // if the search for active
+            if (active != null) {
+                 
+                switch (active) {
+                    case "true": {
+                        var customer = _context.Customer.Where(c => 
+                            _context.Order.Any(o => o.CustomerId == c.CustomerId));
 
-            if (customer == null)
-            {
-                return NotFound();
+                        return Ok(customer);
+                    }
+
+                    case "false": {
+                        
+                        var customer = _context.Customer.Where(c => 
+                            !_context.Order.Any(o => o.CustomerId == c.CustomerId));
+
+                        return Ok(customer);
+                    }
+
+                    default: {
+                        return NotFound();
+                    }
+                }
+                
+
+
+            } else {
+                 var customer = _context.Customer.ToList();
+
+                if (customer == null)
+                {
+                    return NotFound();
+                }
+                    return Ok(customer);
             }
-            return Ok(customer);
+
 
         }
 
 
-        // GET api/values/5
+        // GET api/[controller]/5
         [HttpGet("{id:int}", Name="GetSingleCustomer")]
         public IActionResult Get(int id)
         {
@@ -62,30 +90,6 @@ namespace BangazonAPI.Controllers
             }
         }
 
-        [HttpGet("{active:bool}",Name="GetActiveCustomers")]
-        public IActionResult GetActive(bool active=true)
-        {
-            
-            // // var customer = _context.Customer.ToList();
-            // var customer = from c in _context.Customer
-            //     join o in _context.Order on c.CustomerId equals o.CustomerId into gj
-            //     from subOrder in gj.DefaultIfEmpty()
-            //     select new { c.FirstName, c.LastName };
-
-            // if (customer == null)
-            // {
-            //     return NotFound();
-            // }
-
-            string color = "Yellow";
-            if (active) {
-               color = "Blue";
-            } 
-
-            var obj = new {name = color, active = active};
-            return Ok(obj);
-
-        }
         // POST api/values
         [HttpPost]
         public IActionResult Post([FromBody]Customer customer)


### PR DESCRIPTION
## Link to Ticket

[Display Customers that haven't placed an Order](https://github.com/spooky-oysters/bangazon/issues/11)

## Description of Proposed Changes

By using the URL parameter /customers/?active=false, the JSON response should only contain customers that don't have any orders placed yet.

## Steps to Test

Outline the steps to test

```sh
git fetch --all
git checkout km-11-display-customer
dotnet run
```
- Seed your local database with customers & orders in db browser
```sh

-- clear existing customers
DELETE FROM Customer
INSERT INTO Customer VALUES(null, '1-1-2017', 'Jim', '1-25-2018', 'Jiminy');
INSERT INTO Customer VALUES(null, '1-1-2018', 'Bob', '1-20-2018', 'Bobbington');

-- clear existing orders		
DELETE FROM `Order`;

-- seed order
INSERT INTO `Order`
	SELECT null,
		null,
		c.CustomerId,
		null
	FROM Customer c
	WHERE c.FirstName='Jim' and c.LastName="Jiminy";
```
Be sure to hit the "Write Changes" button, if you used DB Browser

### In Postman
make a GET to localhost:5000/api/customer/?active=false
Should return customers without records in the order table:
```sh
[
    {
        "customerId": 2,
        "firstName": "Bob",
        "lastName": "Bobiny",
        "creationDate": "2018-01-26T00:00:00",
        "lastLoginDate": "2018-01-26T00:00:00"
    }
]
```
- make a GET to localhost:5000/api/customer/?active=true, this should return the customer Jim Jiminy
- Get by Id should still work

## Impacted Areas in Application

List general components of the application that this PR will affect:

* Controllers.Customers

## Mentions @username
----
Tag users that need to review this code

