### PR TITLE
Gl setup cors policy

### DIFF
--- a/BangazonAPI.csproj
+++ b/BangazonAPI.csproj
@@ -10,6 +10,7 @@
 
    <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />

--- a/Controllers/DepartmentController.cs
+++ b/Controllers/DepartmentController.cs
@@ -8,6 +8,7 @@ using BangazonAPI.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Http;
 
+
 namespace BangazonAPI.Controllers
 {
     [Route("api/[controller]")]

--- a/Startup.cs
+++ b/Startup.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.Options;
 using BangazonAPI.Data;
 using Microsoft.EntityFrameworkCore;
 
+// CORS setup by Greg Lawrence
+
 namespace BangazonAPI
 {
     public class Startup
@@ -29,12 +31,14 @@ namespace BangazonAPI
             // Add CORS framework
             services.AddCors(options =>
             {
-                // define a CORS policy
+                // define a CORS policy to use
+                // this policy will restrict api usage to just users on http://bangazon.com
                 options.AddPolicy("AllowOnlyTheseOrigins",
                     builder => builder.WithOrigins("http://bangazon.com"));
             });
 
             services.AddMvc();
+            // define path to database
             string path = System.Environment.GetEnvironmentVariable("BANGAZON_API_DB");
             var connection = $"Filename={path}";
             Console.WriteLine($"connection = {connection}");

--- a/Startup.cs
+++ b/Startup.cs
@@ -34,7 +34,7 @@ namespace BangazonAPI
                 // define a CORS policy to use
                 // this policy will restrict api usage to just users on http://bangazon.com
                 options.AddPolicy("AllowOnlyTheseOrigins",
-                    builder => builder.WithOrigins("http://bangazon.com"));
+                    builder => builder.WithOrigins("http://bangazon.com:8080", "http://bangazon.com:5000"));
             });
 
             services.AddMvc();

--- a/Startup.cs
+++ b/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -25,11 +26,20 @@ namespace BangazonAPI
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            // Add CORS framework
+            services.AddCors(options =>
+            {
+                // define a CORS policy
+                options.AddPolicy("AllowOnlyTheseOrigins",
+                    builder => builder.WithOrigins("http://bangazon.com"));
+            });
+
             services.AddMvc();
             string path = System.Environment.GetEnvironmentVariable("BANGAZON_API_DB");
             var connection = $"Filename={path}";
             Console.WriteLine($"connection = {connection}");
             services.AddDbContext<BangazonAPIContext>(options => options.UseSqlite(connection));
+            
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -39,6 +49,9 @@ namespace BangazonAPI
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            // Use the CORS policy you created in ConfigureServices
+            app.UseCors("AllowOnlyTheseOrigins");
 
             app.UseMvc();
         }


### PR DESCRIPTION
## Link to Ticket

TITLE [Link](https://github.com/spooky-oysters/bangazon/issues/12)
Allow only Bangazonians access to the API 

## Description of Proposed Changes

- Added CORS policy to restrict api usage to only users from http://bangazon.com domain


## Steps to Test

Run:
```sh
git fetch --all
git checkout gl-setupCORSPolicy

```

- Run: (on a Mac)
```sh
sudo nano /private/etc/hosts 
```  
to open your hosts file on your computer and create a NEW host alias. (Do not edit the current alias set for Localhost).
- Use ```127.0.0.1        bangazon.com``` as your alias.
- Type `control-key o` to save your host file. That is the letter "o". 

Then start your server with:
```sh
dotnet run

```

API access should still work for you. 
  




## Impacted Areas in Application

List general components of the application that this PR will affect:

* Entire API access
* Startup.cs


## Mentions @username

Tag users that need to review this code







